### PR TITLE
feat: add image audit and validation pipeline

### DIFF
--- a/packages/titanengine/src/handlers/audit-images.ts
+++ b/packages/titanengine/src/handlers/audit-images.ts
@@ -1,0 +1,8 @@
+import { TitanEngine } from '../service/titanengine';
+
+const engine = TitanEngine.createDefault();
+
+export async function handler() {
+  await engine.auditImageAssets();
+  return { statusCode: 200, body: 'audit complete' };
+}

--- a/packages/titanengine/src/index.ts
+++ b/packages/titanengine/src/index.ts
@@ -2,6 +2,7 @@ export * from './providers';
 export * from './repository/image-asset-repository';
 export * from './service/titanengine';
 export * from './handlers/http-handlers';
+export * from './handlers/audit-images';
 export * from './service/dspy-bridge';
 export * from './service/kcache';
 

--- a/packages/web-app/src/app/api/validate-image/route.ts
+++ b/packages/web-app/src/app/api/validate-image/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { TitanEngine } from '@madmall/titanengine';
+
+const engine = TitanEngine.createDefault();
+
+export async function POST(req: NextRequest) {
+  const { url, altText, category } = await req.json();
+  if (!url || !altText || !category) {
+    return NextResponse.json({ error: 'url, altText and category are required' }, { status: 400 });
+  }
+  const result = await engine.validateImageContent({ url, altText, category });
+  return NextResponse.json(result);
+}

--- a/packages/web-app/src/components/ui/CommunityImage.tsx
+++ b/packages/web-app/src/components/ui/CommunityImage.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
+import { validateImageContent } from '../../lib/image-validation';
 
 interface CommunityImageProps {
   category: 'community' | 'wellness' | 'lifestyle' | 'portraits';
@@ -43,7 +44,26 @@ export default function CommunityImage({
     return placeholders[category] || '/images/default-placeholder.jpg';
   };
 
-  const imageUrl = src || getPlaceholderImage();
+  const [imageUrl, setImageUrl] = useState(src || getPlaceholderImage());
+
+  useEffect(() => {
+    const runValidation = async () => {
+      if (!src) return;
+      try {
+        const result = await validateImageContent({ url: src, altText: alt || '', category });
+        const ok =
+          result.cultural >= 0.8 &&
+          result.inclusivity >= 0.8 &&
+          !(result.issues || []).some((i) => i.includes('cultural_mismatch'));
+        if (!ok) {
+          setImageUrl(getPlaceholderImage());
+        }
+      } catch (err) {
+        setImageUrl(getPlaceholderImage());
+      }
+    };
+    runValidation();
+  }, [src, alt, category]);
   
   const sizeConfig = {
     small: { width: 120, height: 120 },

--- a/packages/web-app/src/lib/image-validation.ts
+++ b/packages/web-app/src/lib/image-validation.ts
@@ -1,0 +1,24 @@
+export interface ImageValidationInput {
+  url: string;
+  altText: string;
+  category: string;
+}
+
+export interface ImageValidationResult {
+  cultural: number;
+  sensitivity: number;
+  inclusivity: number;
+  issues?: string[];
+}
+
+export async function validateImageContent(input: ImageValidationInput): Promise<ImageValidationResult> {
+  const res = await fetch('/api/validate-image', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    throw new Error('Image validation failed');
+  }
+  return res.json();
+}

--- a/packages/web-app/src/lib/upload-image.ts
+++ b/packages/web-app/src/lib/upload-image.ts
@@ -1,0 +1,14 @@
+import { validateImageContent } from './image-validation';
+
+export async function validateBeforeUpload(file: File, category: string) {
+  const previewUrl = URL.createObjectURL(file);
+  const result = await validateImageContent({ url: previewUrl, altText: file.name, category });
+  const ok =
+    result.cultural >= 0.8 &&
+    result.inclusivity >= 0.8 &&
+    !(result.issues || []).some((i) => i.includes('cultural_mismatch'));
+  if (!ok) {
+    throw new Error('Image failed cultural validation');
+  }
+  return result;
+}


### PR DESCRIPTION
### **User description**
## Summary
- audit existing image assets and replace culturally misaligned items with TitanEngine placeholders
- expose API and frontend utilities for image content validation
- validate uploaded and viewed images against cultural criteria

## Testing
- `pnpm test` *(fails: Invalid package.json in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c3aacc008320a36f539f98a4c0ed


___

### **PR Type**
Enhancement


___

### **Description**
- Add image audit pipeline for cultural validation

- Implement API endpoint for image content validation

- Add frontend validation for uploads and display

- Replace non-compliant images with placeholders


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Image Upload"] --> B["Validation API"]
  B --> C["Cultural Scoring"]
  C --> D["Pass/Fail Check"]
  D --> E["Replace with Placeholder"]
  D --> F["Keep Original"]
  G["Audit Handler"] --> H["Batch Process Images"]
  H --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audit-images.ts</strong><dd><code>Add audit handler for image processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/titanengine/src/handlers/audit-images.ts

<ul><li>Create new handler for image auditing<br> <li> Initialize TitanEngine and call auditImageAssets method<br> <li> Return success response after audit completion</ul>


</details>


  </td>
  <td><a href="https://github.com/coreyalejandro/kiro-hackathon-mad-mall/pull/13/files#diff-8925a062cb855f6e63b2872f2ae3e9ec7fdf76930162caf227f66e5fcfa8cd33">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export audit handler module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/titanengine/src/index.ts

- Export audit-images handler module


</details>


  </td>
  <td><a href="https://github.com/coreyalejandro/kiro-hackathon-mad-mall/pull/13/files#diff-19af81f0cef7d3ba9b9a43a41d51a5babca1284a50a443b1b65d503c0269b0b2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>titanengine.ts</strong><dd><code>Implement image audit and replacement logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/titanengine/src/service/titanengine.ts

<ul><li>Add <code>auditImageAssets</code> method for batch processing<br> <li> Validate images against cultural criteria<br> <li> Replace non-compliant images with placeholders<br> <li> Mark images as validated with appropriate status</ul>


</details>


  </td>
  <td><a href="https://github.com/coreyalejandro/kiro-hackathon-mad-mall/pull/13/files#diff-2a8809af8b3a4cd2c1a0f21789f8cfeb0203720079d13f75c4984df6bb62c8cf">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Add image validation API endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/web-app/src/app/api/validate-image/route.ts

<ul><li>Create POST endpoint for image validation<br> <li> Accept url, altText, and category parameters<br> <li> Return validation results from TitanEngine</ul>


</details>


  </td>
  <td><a href="https://github.com/coreyalejandro/kiro-hackathon-mad-mall/pull/13/files#diff-c7881fc406f1615e7f5d85d71026b38c276aa825fa0dc3996a59b21e257ec871">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>image-validation.ts</strong><dd><code>Add image validation utility functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/web-app/src/lib/image-validation.ts

<ul><li>Define interfaces for validation input and results<br> <li> Create client-side validation function<br> <li> Handle API communication for image validation</ul>


</details>


  </td>
  <td><a href="https://github.com/coreyalejandro/kiro-hackathon-mad-mall/pull/13/files#diff-480f93a6385e064ab8da6227082e6471af4d516cf8a9b3bfe6fdf87c5faea5e8">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>upload-image.ts</strong><dd><code>Add upload validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/web-app/src/lib/upload-image.ts

<ul><li>Add pre-upload validation function<br> <li> Check cultural and inclusivity scores<br> <li> Throw error for non-compliant images</ul>


</details>


  </td>
  <td><a href="https://github.com/coreyalejandro/kiro-hackathon-mad-mall/pull/13/files#diff-5c5b544c6efb2d9a30264615794c678cb78fbe1424695e85b8f09a6bdf25e597">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CommunityImage.tsx</strong><dd><code>Add runtime validation to image component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/web-app/src/components/ui/CommunityImage.tsx

<ul><li>Add runtime image validation on display<br> <li> Replace non-compliant images with placeholders<br> <li> Use state management for dynamic image URLs</ul>


</details>


  </td>
  <td><a href="https://github.com/coreyalejandro/kiro-hackathon-mad-mall/pull/13/files#diff-3cd7cd06a5cd1a5b18d818c700d3a70a28bdb810d5c4ba62e97b215ab2ad0975">+22/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

