### PR TITLE
feat: add concourse navigation and activity feed

### DIFF
--- a/packages/web-app/jest.config.js
+++ b/packages/web-app/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/packages/web-app/jest.setup.ts
+++ b/packages/web-app/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/packages/web-app/src/components/pages/ConcourseContent.tsx
+++ b/packages/web-app/src/components/pages/ConcourseContent.tsx
@@ -1,8 +1,14 @@
 'use client';
 
 import { Container, Header, ContentLayout } from '@cloudscape-design/components';
+import { useMallSections, useCommunityActivity } from '@/lib/queries';
+import { useRouter } from 'next/navigation';
 
 export function ConcourseContent() {
+  const router = useRouter();
+  const { data: mallSections } = useMallSections();
+  const { data: communityActivity } = useCommunityActivity();
+
   return (
     <ContentLayout
       header={
@@ -50,6 +56,48 @@ export function ConcourseContent() {
             </div>
           </div>
         </div>
+      </Container>
+
+      <Container className="mt-8">
+        <Header variant="h2">Explore the Mall</Header>
+        {mallSections?.data ? (
+          <div className="mall-sections-grid">
+            {mallSections.data.map(section => (
+              <div
+                key={section.id}
+                className="mall-section-card"
+                role="button"
+                tabIndex={0}
+                data-testid={`mall-section-${section.id}`}
+                onClick={() => router.push(section.href)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') router.push(section.href);
+                }}
+              >
+                <div className="mall-section-icon">{section.icon}</div>
+                <h3>{section.title}</h3>
+                <p>{section.description}</p>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div>Loading sections...</div>
+        )}
+      </Container>
+
+      <Container className="mt-8">
+        <Header variant="h2">Community Activity</Header>
+        {communityActivity?.data ? (
+          <ul className="community-activity-list">
+            {communityActivity.data.map(item => (
+              <li key={item.id} className="community-activity-item">
+                <span className="activity-user">{item.user.name}</span> {item.content}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div>Loading activity...</div>
+        )}
       </Container>
     </ContentLayout>
   );

--- a/packages/web-app/src/components/pages/__tests__/ConcourseContent.test.tsx
+++ b/packages/web-app/src/components/pages/__tests__/ConcourseContent.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ConcourseContent } from '../ConcourseContent';
+import { useRouter } from 'next/navigation';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+const renderWithClient = () => {
+  const queryClient = new QueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ConcourseContent />
+    </QueryClientProvider>
+  );
+};
+
+test('navigates to section within 2s on card click', async () => {
+  const push = jest.fn();
+  (useRouter as jest.Mock).mockReturnValue({ push });
+  renderWithClient();
+  const card = await screen.findByTestId('mall-section-peer-circles');
+  await userEvent.click(card);
+  await waitFor(() => {
+    expect(push).toHaveBeenCalledWith('/circles');
+  }, { timeout: 2000 });
+});
+
+test('displays community activity', async () => {
+  (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+  renderWithClient();
+  const items = await screen.findAllByRole('listitem');
+  expect(items.length).toBeGreaterThan(0);
+});
+

--- a/packages/web-app/src/styles/concourse-interactions.css
+++ b/packages/web-app/src/styles/concourse-interactions.css
@@ -1,5 +1,25 @@
 /* Concourse Interactive Hover Effects and Visual Feedback */
 
+/* Mall Sections grid layout */
+.mall-sections-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+/* Community activity list */
+.community-activity-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.community-activity-item {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #e0e0e0;
+}
+
 /* Mall Section Cards - Enhanced Hover Effects */
 .mall-section-card {
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);


### PR DESCRIPTION
## Summary
- show mall section navigation grid on Concourse
- render community activity feed
- add tests verifying navigation on section cards

## Testing
- `pnpm --filter @madmall/web-app lint` *(fails: Invalid package.json in package.json)*
- `npm test --workspaces --if-present` *(fails: Invalid package.json: JSONParseError)*
- `yes | npx jest@29 -c packages/web-app/jest.config.js packages/web-app/src/components/pages/__tests__/ConcourseContent.test.tsx` *(fails: Error parsing packages/web-app/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c3c8dd848320b5ad7a1d4fd4efcc

## Summary by Sourcery

Add Mall sections navigation grid and community activity feed to the Concourse page, complete with data fetching, styles, tests, and Jest configuration.

New Features:
- Render an Explore the Mall grid of section cards with click and keyboard navigation
- Display a Community Activity feed listing recent activity items

Enhancements:
- Fetch mall sections and community activity via useMallSections and useCommunityActivity hooks
- Add styles for the mall sections grid and community activity list

Build:
- Add Jest configuration (jest.config.js) and setup file for the web-app package

Tests:
- Add test verifying navigation to a mall section on card click
- Add test ensuring community activity items are rendered