### PR TITLE
feat: add bedrock sdxl provider

### DIFF
--- a/packages/titanengine/README.md
+++ b/packages/titanengine/README.md
@@ -1,6 +1,6 @@
 # TitanEngine
 
-Image curation and generation service with AWS Bedrock integration. Provides importers for Pexels, Unsplash, Automatic1111, and a Placeholder provider. Persists `DynamoDBImageAsset` entities via the shared DynamoDB single-table design and runs cultural validation using Bedrock agents.
+Image curation and generation service with AWS Bedrock integration. Provides importers for Pexels, Unsplash, Automatic1111, a Bedrock SDXL generator, and a Placeholder provider. Persists `DynamoDBImageAsset` entities via the shared DynamoDB single-table design and runs cultural validation using Bedrock agents.
 
 ## Env Vars
 

--- a/packages/titanengine/src/providers/bedrock-sdxl-provider.ts
+++ b/packages/titanengine/src/providers/bedrock-sdxl-provider.ts
@@ -1,0 +1,54 @@
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
+
+export interface BedrockSDXLParams {
+  prompt: string;
+  steps?: number;
+  cfgScale?: number;
+  width?: number;
+  height?: number;
+  count?: number;
+}
+
+export interface GeneratedImage {
+  imageBase64: string;
+}
+
+export class BedrockSDXLProvider {
+  private readonly client: BedrockRuntimeClient;
+  private readonly modelId: string;
+
+  constructor(region?: string, modelId?: string) {
+    const r = region || process.env.AWS_REGION || 'us-east-1';
+    this.client = new BedrockRuntimeClient({ region: r });
+    this.modelId = modelId || process.env.BEDROCK_SDXL_MODEL || 'stability.stable-diffusion-xl-v1';
+  }
+
+  async generate(params: BedrockSDXLParams): Promise<GeneratedImage[]> {
+    const body = {
+      text_prompts: [{ text: params.prompt }],
+      cfg_scale: params.cfgScale ?? 10,
+      steps: params.steps ?? 30,
+      width: params.width ?? 1024,
+      height: params.height ?? 1024,
+      samples: params.count ?? 1,
+    };
+
+    const command = new InvokeModelCommand({
+      modelId: this.modelId,
+      contentType: 'application/json',
+      accept: 'application/json',
+      body: JSON.stringify(body),
+    });
+
+    try {
+      const res = await this.client.send(command);
+      if (!res.body) return [];
+      const json = JSON.parse(new TextDecoder().decode(res.body));
+      const artifacts = Array.isArray(json.artifacts) ? json.artifacts : [];
+      return artifacts.map((a: any) => ({ imageBase64: a.base64 }));
+    } catch {
+      return [];
+    }
+  }
+}
+

--- a/packages/titanengine/src/providers/index.ts
+++ b/packages/titanengine/src/providers/index.ts
@@ -2,4 +2,5 @@ export * from './pexels-provider';
 export * from './unsplash-provider';
 export * from './automatic1111-provider';
 export * from './placeholder-provider';
+export * from './bedrock-sdxl-provider';
 


### PR DESCRIPTION
### **User description**
## Summary
- add Bedrock SDXL provider for image generation
- wire Bedrock generator into TitanEngine with cultural validation before storage
- document Bedrock provider in TitanEngine README

## Testing
- `npx -y -p typescript -p @types/node tsc -p packages/titanengine/tsconfig.json` *(fails: Cannot find type definition file for 'node')*
- `npx -y -p jest jest packages/titanengine` *(fails: Cannot parse package.json: Expected double-quoted property name in JSON at position 1180)*


------
https://chatgpt.com/codex/tasks/task_e_68c4c3bafe308320ab3f31d6d1b0b7bc


___

### **PR Type**
Enhancement


___

### **Description**
- Add Bedrock SDXL provider for AI image generation

- Integrate Bedrock generator with cultural validation pipeline

- Wire new provider into TitanEngine service

- Update documentation to include Bedrock support


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BedrockSDXLProvider"] --> B["TitanEngine"]
  B --> C["Cultural Validation"]
  C --> D["DynamoDB Storage"]
  E["AWS Bedrock Runtime"] --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bedrock-sdxl-provider.ts</strong><dd><code>New Bedrock SDXL image generation provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/titanengine/src/providers/bedrock-sdxl-provider.ts

<ul><li>Create new BedrockSDXLProvider class with AWS SDK integration<br> <li> Implement generate method with configurable parameters<br> <li> Add error handling and base64 image response parsing<br> <li> Support customizable model ID and region configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/coreyalejandro/kiro-hackathon-mad-mall/pull/16/files#diff-f667c96851e3c0ae349930b252f7b765c8806217344c232ac170130559ac0e8f">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>titanengine.ts</strong><dd><code>Integrate Bedrock provider into TitanEngine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/titanengine/src/service/titanengine.ts

<ul><li>Import and instantiate BedrockSDXLProvider<br> <li> Add generateWithBedrock method with cultural validation<br> <li> Integrate Bedrock generation with existing validation pipeline<br> <li> Store generated images with proper metadata and status</ul>


</details>


  </td>
  <td><a href="https://github.com/coreyalejandro/kiro-hackathon-mad-mall/pull/16/files#diff-2a8809af8b3a4cd2c1a0f21789f8cfeb0203720079d13f75c4984df6bb62c8cf">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export new Bedrock provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/titanengine/src/providers/index.ts

- Export BedrockSDXLProvider from providers module


</details>


  </td>
  <td><a href="https://github.com/coreyalejandro/kiro-hackathon-mad-mall/pull/16/files#diff-58b3e3c5a812a449ebd6e0948e1922288eb60f977f5065b8ddbf7670e3e98e8e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation for Bedrock support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/titanengine/README.md

- Update service description to include Bedrock SDXL generator


</details>


  </td>
  <td><a href="https://github.com/coreyalejandro/kiro-hackathon-mad-mall/pull/16/files#diff-c3b6b06e135fc6dce028407f4b6ef40ae2ea8eb2e89f58ec621e0e0037479059">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

