### PR TITLE
feat(titanengine): route analytics events through TitanEngine

### DIFF
--- a/packages/titanengine/src/index.ts
+++ b/packages/titanengine/src/index.ts
@@ -5,4 +5,5 @@ export * from './handlers/http-handlers';
 export * from './handlers/audit-images';
 export * from './service/dspy-bridge';
 export * from './service/kcache';
+export * from './service/analytics-processor';
 

--- a/packages/titanengine/src/service/analytics-processor.ts
+++ b/packages/titanengine/src/service/analytics-processor.ts
@@ -1,0 +1,34 @@
+import { TitanKCache } from './kcache';
+
+export interface TitanEvent {
+  userId: string;
+  eventType: 'page' | 'interaction';
+  name: string;
+  timestamp?: number;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Basic analytics processor that stores events in TitanKCache so that
+ * recommendation pipelines can leverage recent user activity.
+ */
+export class TitanAnalyticsProcessor {
+  private readonly cache: TitanKCache<TitanEvent[]>;
+
+  constructor(cache: TitanKCache<TitanEvent[]>) {
+    this.cache = cache;
+  }
+
+  async record(event: TitanEvent): Promise<void> {
+    const fullEvent: TitanEvent = { ...event, timestamp: event.timestamp || Date.now() };
+    const key = ['events', fullEvent.userId];
+    const existing = (await this.cache.get(key)) || [];
+    existing.push(fullEvent);
+    await this.cache.set(key, existing);
+  }
+
+  async getEvents(userId: string): Promise<TitanEvent[]> {
+    return (await this.cache.get(['events', userId])) || [];
+  }
+}
+


### PR DESCRIPTION
## Summary
- add TitanAnalyticsProcessor with TitanKCache-backed event storage
- route page and interaction events through TitanEngine and persist to DynamoDB
- include recent events in recommendation cache key and history for refined results

## Testing
- `npx tsc -p packages/titanengine/tsconfig.json` *(fails: Cannot find type definition file for 'node')*
- `npx jest packages/titanengine` *(fails: Need to install the following packages: jest@30.1.3)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d9a7d4248320af8c4c142eb24c9d

## Summary by Sourcery

Introduce analytics event routing through TitanEngine by adding a processor, tracking events, and incorporating them into recommendation logic.

New Features:
- Add TitanAnalyticsProcessor for caching user analytics events in TitanKCache
- Expose trackEvent in TitanEngine to record events to cache and DynamoDB
- Route page and interaction events through TitanEngine and persist them to DynamoDB
- Integrate recent analytics events into recommendation cache key and history for refined results
- Export analytics-processor in the public TitanEngine API