### PR TITLE
feat: schedule nightly image audit and expose flagged images

### DIFF
--- a/packages/titanengine/src/handlers/http-handlers.ts
+++ b/packages/titanengine/src/handlers/http-handlers.ts
@@ -14,6 +14,10 @@ export async function getPending() {
   return engine.listPending();
 }
 
+export async function getFlagged() {
+  return engine.listFlagged();
+}
+
 export async function postValidate(body: { imageId: string }) {
   const pending = await engine.listPending(100);
   const found = pending.find(p => p.imageId === body.imageId);

--- a/packages/titanengine/src/repository/image-asset-repository.ts
+++ b/packages/titanengine/src/repository/image-asset-repository.ts
@@ -72,6 +72,11 @@ export class ImageAssetRepository extends BaseDynamoDAO<DynamoDBImageAsset> {
     return items as DynamoDBImageAsset[];
   }
 
+  async listFlagged(limit = 20) {
+    const { items } = await this.queryGSI('GSI3', KeyPatterns.IMAGE_STATUS('flagged').GSI3PK, undefined, { limit });
+    return items as DynamoDBImageAsset[];
+  }
+
   async selectByCategory(category: string, limit = 1) {
     const { items } = await this.queryGSI('GSI1', KeyPatterns.IMAGES_BY_CATEGORY(category).GSI1PK, undefined, {
       limit,


### PR DESCRIPTION
### **User description**
## Summary
- schedule titan-engine lambda to audit images nightly
- log audit scores in DynamoDB and expose flagged assets over HTTP

## Testing
- `pnpm test --filter @madmall/titanengine` *(fails: Invalid package.json in ../../package.json)*
- `npm test` *(fails: jest: not found)*
- `pnpm test --filter @madmall/infrastructure` *(fails: Invalid package.json in ../../package.json)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d9dbc3608320bf37ed39ac4d64c7


___

### **PR Type**
Enhancement


___

### **Description**
- Schedule nightly image audit using EventBridge cron rule

- Add flagged images endpoint and repository method

- Log audit results to DynamoDB with scores

- Integrate audit scheduling with titan-engine lambda


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["EventBridge Rule"] -- "triggers nightly" --> B["titan-engine Lambda"]
  B -- "audits images" --> C["Image Repository"]
  B -- "logs results" --> D["DynamoDB Audit Log"]
  C -- "queries flagged" --> E["HTTP Endpoint"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lambda.ts</strong><dd><code>Add EventBridge scheduling for titan-engine lambda</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/infrastructure/src/constructs/lambda.ts

<ul><li>Import EventBridge Rule and Schedule classes<br> <li> Add <code>scheduleAudit</code> method with cron rule for midnight execution<br> <li> Conditionally schedule audit for <code>titan-engine</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/coreyalejandro/kiro-hackathon-mad-mall/pull/22/files#diff-a406e39d443679054d9f02c45774b4090de39fe3921d8319a8dc239f12c5e602">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>http-handlers.ts</strong><dd><code>Add flagged images HTTP handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/titanengine/src/handlers/http-handlers.ts

<ul><li>Add <code>getFlagged</code> handler function<br> <li> Expose flagged images through HTTP endpoint</ul>


</details>


  </td>
  <td><a href="https://github.com/coreyalejandro/kiro-hackathon-mad-mall/pull/22/files#diff-47381af2ec815bb653e963e9457977d453d0ed0e3e2fd044846ab6ffbc62b086">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>image-asset-repository.ts</strong><dd><code>Add repository method for flagged images</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/titanengine/src/repository/image-asset-repository.ts

<ul><li>Add <code>listFlagged</code> method to query flagged images<br> <li> Use GSI3 with flagged status key pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/coreyalejandro/kiro-hackathon-mad-mall/pull/22/files#diff-3a0b3c61760a532294c23fb71fe7dbeeadfd22d274e701ae088f72d1127a996b">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>titanengine.ts</strong><dd><code>Add audit logging and flagged images service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/titanengine/src/service/titanengine.ts

<ul><li>Add <code>logAuditResult</code> method to store audit scores in DynamoDB<br> <li> Call audit logging in image validation workflow<br> <li> Add <code>listFlagged</code> service method</ul>


</details>


  </td>
  <td><a href="https://github.com/coreyalejandro/kiro-hackathon-mad-mall/pull/22/files#diff-2a8809af8b3a4cd2c1a0f21789f8cfeb0203720079d13f75c4984df6bb62c8cf">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

