### PR TITLE
feat: enforce titan engine config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,4 +17,5 @@ DYNAMODB_TABLE_NAME=madmall-development-main
 USER_CONTENT_BUCKET=madmall-development-user-content
 
 # Common app vars
-NEXT_PUBLIC_API_BASE_URL=http://localhost:3000/api
+NEXT_PUBLIC_API_URL=http://localhost:3001
+TITAN_ENGINE_URL=http://localhost:3002

--- a/packages/web-app/README.md
+++ b/packages/web-app/README.md
@@ -70,8 +70,8 @@ The application supports different environment configurations:
 
 ### Environment Variables
 
-- `NEXT_PUBLIC_API_URL` - API base URL
-- `NEXT_PUBLIC_TITANENGINE_URL` - TitanEngine service URL
+- `NEXT_PUBLIC_API_URL` - API base URL (required)
+- `TITAN_ENGINE_URL` - TitanEngine service URL (required)
 - `NEXT_PUBLIC_ENABLE_DEBUG` - Enable debug mode
 
 ## Styling

--- a/packages/web-app/src/app/layout.tsx
+++ b/packages/web-app/src/app/layout.tsx
@@ -6,6 +6,9 @@ import '@/styles/concourse-interactions.css';
 import { AppLayout, TopNavigation, SideNavigation } from '@cloudscape-design/components';
 import { NavigationProvider } from '@/components/providers/NavigationProvider';
 import { QueryProvider } from '@/components/providers/QueryProvider';
+import { env } from '@/lib/env';
+
+void env; // trigger environment validation on bootstrap
 
 export const metadata: Metadata = {
   title: 'AIme - MADMall Social Wellness Hub',

--- a/packages/web-app/src/lib/env.ts
+++ b/packages/web-app/src/lib/env.ts
@@ -2,22 +2,38 @@
  * Environment variable utilities for different deployment environments
  */
 
+function requireUrlEnv(...names: string[]): string {
+  for (const name of names) {
+    const value = process.env[name];
+    if (value) {
+      try {
+        // eslint-disable-next-line no-new
+        new URL(value);
+      } catch {
+        throw new Error(`Environment variable ${name} must be a valid URL`);
+      }
+      return value;
+    }
+  }
+  throw new Error(`Missing required environment variable: ${names[0]}`);
+}
+
 export const env = {
   // API Configuration
-  API_URL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001',
+  API_URL: requireUrlEnv('NEXT_PUBLIC_API_URL'),
   API_VERSION: process.env.NEXT_PUBLIC_API_VERSION || 'v1',
-  
+
   // TitanEngine Configuration
-  TITANENGINE_URL: process.env.NEXT_PUBLIC_TITANENGINE_URL || 'http://localhost:3002',
-  
+  TITAN_ENGINE_URL: requireUrlEnv('TITAN_ENGINE_URL', 'NEXT_PUBLIC_TITANENGINE_URL', 'NEXT_PUBLIC_TITAN_ENGINE_URL'),
+
   // Authentication
   AUTH_DOMAIN: process.env.NEXT_PUBLIC_AUTH_DOMAIN || '',
   AUTH_CLIENT_ID: process.env.NEXT_PUBLIC_AUTH_CLIENT_ID || '',
-  
+
   // Feature Flags
   ENABLE_ANALYTICS: process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === 'true',
   ENABLE_DEBUG: process.env.NEXT_PUBLIC_ENABLE_DEBUG === 'true',
-  
+
   // Environment Detection
   isDevelopment: process.env.NODE_ENV === 'development',
   isProduction: process.env.NODE_ENV === 'production',
@@ -36,7 +52,7 @@ export function getApiUrl(endpoint: string = ''): string {
  * Get TitanEngine URL with endpoint
  */
 export function getTitanEngineUrl(endpoint: string = ''): string {
-  return endpoint ? `${env.TITANENGINE_URL}/${endpoint.replace(/^\//, '')}` : env.TITANENGINE_URL;
+  return endpoint ? `${env.TITAN_ENGINE_URL}/${endpoint.replace(/^\//, '')}` : env.TITAN_ENGINE_URL;
 }
 
 /**


### PR DESCRIPTION
## Summary
- validate critical env vars like TITAN_ENGINE_URL at startup
- document required runtime config and provide example values

## Testing
- `pnpm --filter @madmall/web-app lint` *(fails: Invalid package.json in package.json)*
- `npx tsc --noEmit` *(fails: src/components/pages/ConcourseContent.tsx(1,1): error TS1128)*
- `npx jest` *(fails: Need to install the following packages: jest@30.1.3)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d9daa0948320837022a7369f5faa

## Summary by Sourcery

Enforce the presence and validity of critical environment variables for the Titan engine and API by introducing a URL validation utility, updating configuration retrieval, triggering checks on app startup, and documenting the required settings.

New Features:
- Enforce runtime validation of critical URL environment variables at startup
- Add requireUrlEnv utility for validating and retrieving required URL env vars

Enhancements:
- Replace default fallbacks for API and TitanEngine URLs with required env var validation
- Update getTitanEngineUrl to reference the renamed TITAN_ENGINE_URL key
- Trigger environment validation in app layout on bootstrap

Documentation:
- Mark NEXT_PUBLIC_API_URL and TITAN_ENGINE_URL as required in README and add .env.example