### PR TITLE
Validate component images via Titan API

### DIFF
--- a/packages/web-app/src/components/ui/CommunityImage.tsx
+++ b/packages/web-app/src/components/ui/CommunityImage.tsx
@@ -50,15 +50,31 @@ export default function CommunityImage({
     const runValidation = async () => {
       if (!src) return;
       try {
-        const result = await validateImageContent({ url: src, altText: alt || '', category });
+        const result = await validateImageContent({
+          url: src,
+          altText: alt || '',
+          category,
+        });
         const ok =
           result.cultural >= 0.8 &&
           result.inclusivity >= 0.8 &&
           !(result.issues || []).some((i) => i.includes('cultural_mismatch'));
         if (!ok) {
+          console.warn('Image failed cultural validation', {
+            src,
+            alt,
+            category,
+            result,
+          });
           setImageUrl(getPlaceholderImage());
         }
       } catch (err) {
+        console.error('TitanEngine validation failed', {
+          error: err,
+          src,
+          alt,
+          category,
+        });
         setImageUrl(getPlaceholderImage());
       }
     };


### PR DESCRIPTION
## Summary
- validate hero section images with `/api/validate-image` and log Titan failures
- add cultural validation to community, avatar, and comedy player images

## Testing
- `npm test` *(fails: Invalid package.json: Expected double-quoted property name)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d9c8d4108320a3a3af1b47e5556b

## Summary by Sourcery

Integrate Titan API-based cultural and inclusivity checks into key image-rendering components and provide fallback handling for invalid content

New Features:
- Validate hero section images via the `/api/validate-image` endpoint before rendering
- Apply cultural validation to community images through the Titan API
- Enforce cultural and inclusivity checks on avatar images using Titan
- Validate and optionally replace ComedyTherapyPlayer thumbnails based on Titan checks