### PR TITLE
feat: add cultural image audit pipeline

### DIFF
--- a/packages/titanengine/src/providers/placeholder-provider.ts
+++ b/packages/titanengine/src/providers/placeholder-provider.ts
@@ -16,15 +16,18 @@ export interface ImportedImage {
 export class PlaceholderProvider {
   async generate(params: PlaceholderParams): Promise<ImportedImage[]> {
     const n = params.count ?? 3;
-    return Array.from({ length: n }).map((_, idx) => ({
-      url: `https://picsum.photos/seed/${encodeURIComponent(params.category)}-${idx}/1200/800`,
-      altText: `${params.category} placeholder`,
-      category: params.category,
-      source: 'stock',
-      sourceInfo: { provider: 'placeholder' },
-      tags: [params.category],
-      thumbnailUrl: `https://picsum.photos/seed/${encodeURIComponent(params.category)}-${idx}/600/400`,
-    }));
+    return Array.from({ length: n }).map((_, idx) => {
+      const seed = `${encodeURIComponent(params.category)}-${idx}`;
+      return {
+        url: `https://placehold.co/1200x800/000000/FFFFFF.png?text=Black+Woman+${idx + 1}`,
+        altText: `Culturally appropriate placeholder for ${params.category}`,
+        category: params.category,
+        source: 'placeholder',
+        sourceInfo: { provider: 'placeholder', seed },
+        tags: [params.category, 'black_woman', 'placeholder'],
+        thumbnailUrl: `https://placehold.co/600x400/000000/FFFFFF.png?text=Black+Woman+${idx + 1}`,
+      };
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- add culturally appropriate placeholder provider
- add TitanEngine methods to validate and audit images, replacing flagged assets

## Testing
- `pnpm --filter @madmall/titanengine test` *(fails: Invalid package.json in ../../package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c2f8d85c8320a9463a4edeba53b8

## Summary by Sourcery

Introduce a cultural image audit pipeline by extending TitanEngine with image validation and auditing methods and updating the placeholder provider to supply culturally appropriate replacements.

New Features:
- Add validateImageContent method to TitanEngine to score images for cultural relevance, sensitivity, and inclusivity and mark validation status
- Add auditImageAssets method to TitanEngine to scan pending and flagged images, remove inappropriate assets, and generate culturally tailored replacements
- Update PlaceholderProvider to generate culturally appropriate placeholder images with updated URLs, altText, tags, and source metadata